### PR TITLE
GetRecipient needs to allow `null` return type for one-click

### DIFF
--- a/src/Model/StrexTransaction.php
+++ b/src/Model/StrexTransaction.php
@@ -97,7 +97,7 @@ class StrexTransaction extends StrexData
         return $this;
     }
 
-    public function getRecipient(): string
+    public function getRecipient(): ?string
     {
         return $this->recipient;
     }


### PR DESCRIPTION
At the moment, when the `recipient` property is empty, a PHP error is thrown as the return type is not a string. If you populate the recipient, the API call fails because the value should be empty for one-click. Allowing `null` to be returned by `StrexTransaction::getRecipient()` fixes the problem.