### PR TITLE
Issue #11: Relax psr/log requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "guzzlehttp/guzzle": "~7.0",
     "phpseclib/phpseclib": "~3.0",
     "phpseclib/phpseclib2_compat": "~1.0",
-    "psr/log": "^1.0"
+    "psr/log": "^1.0 || ^3.0"
   },
   "license": "MIT",
   "authors": [


### PR DESCRIPTION
Seems like the usage of `psr/log` is quite standard and allowing `psr/log:^3.0` only requires a simple change to the composer.json