### PR TITLE
Add return type to silence PHP warning.

### DIFF
--- a/src/Model/Properties.php
+++ b/src/Model/Properties.php
@@ -34,7 +34,7 @@ class Properties implements \ArrayAccess, \IteratorAggregate
         unset($this->data[$offset]);
     }
 
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return $this->data[$offset] ?? null;
     }
@@ -96,7 +96,7 @@ class Properties implements \ArrayAccess, \IteratorAggregate
      * <b>Traversable</b>
      * @since 5.0.0
      */
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
         return new \ArrayIterator($this->data);
     }


### PR DESCRIPTION
Using some resource's `list` method causes PHP to show following notices:
- ( ! ) Deprecated: Return type of Target365\ApiSdk\Model\Properties::offsetGet($offset) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /.../vendor/target365/sdk/src/Model/Properties.php on line 37
- ( ! ) Deprecated: Return type of Target365\ApiSdk\Model\Properties::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /.../vendor/target365/sdk/src/Model/Properties.php on line 99

Adding these types silences the notices.